### PR TITLE
Use non-build files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-side-menu",
   "version": "1.1.3",
   "description": "Simple customizable component to create side menu",
-  "main": "build/index.js",
+  "main": "./index.js",
   "scripts": {
     "build": "./build.sh",
     "prepublish": "./build.sh"


### PR DESCRIPTION
The forked project imports the project from an auto-generated build folder. Since we're not publishing to NPM and running a build script, this commit changes our imports to use the files themselves, rather than the build files.

The build files are identical, just copied to a `build` directory. See build.sh